### PR TITLE
Timed commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 config.json
 node_modules/
 package-lock.json
+data/

--- a/commands/cleartriggers.js
+++ b/commands/cleartriggers.js
@@ -1,8 +1,9 @@
 
 exports.run = (client, message, args) => {
     if (!message.author.id == client.config.owner) return;
-    client.triggers.clear(); //clear the whole enmap
     for(let job of client.cronJobs) { //stop all the jobs
         job.stop();
     }
+    client.triggers.clear(); //clear the whole enmap
+    message.channel.send('Cleared all triggers globally');
 }

--- a/commands/cleartriggers.js
+++ b/commands/cleartriggers.js
@@ -1,0 +1,8 @@
+
+exports.run = (client, message, args) => {
+    if (!message.author.id == client.config.owner) return;
+    client.triggers.clear(); //clear the whole enmap
+    for(let job of client.cronJobs) { //stop all the jobs
+        job.stop();
+    }
+}

--- a/commands/removetrigger.js
+++ b/commands/removetrigger.js
@@ -1,0 +1,13 @@
+const { Permissions } = require('discord.js');
+
+exports.run = (client, message, args) => {
+    if (!message.member.permissions.has(Permissions.FLAGS.ADMINISTRATOR)) return;
+    if (!args[0]) return message.channel.send(`Please specify a trigger index (use $triggers to view their numbers)`);
+    let triggers = client.triggers.ensure(message.guild.id, []);
+    let index = args[0]-1; // triggers.js displays with an index starting at 1, so decrement by one for our needs
+    if (!triggers[index]) return message.channel.send(`Couldn't find a trigger with id ${index+1}`);
+    triggers[index].stopJob(); //stop the job
+    triggers.splice(index,1); //remove the trigger object from the array
+    client.triggers.set(message.guild.id, triggers); //set the new triggers (without the one we just removed)
+    client.commands.get("triggers").run(client,message,args); //display the new trigger information
+}

--- a/commands/settrigger.js
+++ b/commands/settrigger.js
@@ -4,13 +4,17 @@ const { CronJob } = require('cron');
 exports.run = (client,message,args,identifiedArgs) => {
     if (!identifiedArgs.t) return message.channel.send('Please specify a time with -t time');
     if (!identifiedArgs.c) return message.channel.send('Please specify a command with -c command');
+    if (!client.commands.get(identifiedArgs.c)) return message.channel.send('Command not found/invalid command');
     const results = chrono.parse(identifiedArgs.t); // chrono parses natural language into datetime
     let datedResult = results[0].start.date(); //get a javascript date object
-    if (!client.commands.get(identifiedArgs.c)) return message.channel.send('Command not found/invalid command');
-    let job = new CronJob(`${datedResult.getMinutes()} ${datedResult.getHours()} * * *`, () => { //set the cronjob for every day using specified hours/minutes
-        let argsToPass = !identifiedArgs.a ? [] : identifiedArgs.a.trim().split(/ +/g);
+    //set the cronjob for every day using specified hours/minutes
+    let job = new CronJob(`${datedResult.getMinutes()} ${datedResult.getHours()} * * *`, () => {
+        //we need to split the data in 'a' to an array. If they didn't specify any args pass an empty array 
+        let argsToPass = !identifiedArgs.a ? [] : identifiedArgs.a.trim().split(/ +/g); 
+        //get the command from the enmap and pass it what it needs
         client.commands.get(identifiedArgs.c).run(client,message,argsToPass);
     });
     job.start();
+    //TODO save needed data to creat cronjob in a persitent enmap
     message.channel.send(`Trigger created. Will run at ${job.nextDate()} next.`);
 }

--- a/commands/settrigger.js
+++ b/commands/settrigger.js
@@ -1,0 +1,16 @@
+const chrono = require('chrono-node');
+const { CronJob } = require('cron');
+
+exports.run = (client,message,args,identifiedArgs) => {
+    if (!identifiedArgs.t) return message.channel.send('Please specify a time with -t time');
+    if (!identifiedArgs.c) return message.channel.send('Please specify a command with -c command');
+    const results = chrono.parse(identifiedArgs.t); // chrono parses natural language into datetime
+    let datedResult = results[0].start.date(); //get a javascript date object
+    if (!client.commands.get(identifiedArgs.c)) return message.channel.send('Command not found/invalid command');
+    let job = new CronJob(`${datedResult.getMinutes()} ${datedResult.getHours()} * * *`, () => { //set the cronjob for every day using specified hours/minutes
+        let argsToPass = !identifiedArgs.a ? [] : identifiedArgs.a.trim().split(/ +/g);
+        client.commands.get(identifiedArgs.c).run(client,message,argsToPass);
+    });
+    job.start();
+    message.channel.send(`Trigger created. Will run at ${job.nextDate()} next.`);
+}

--- a/commands/settrigger.js
+++ b/commands/settrigger.js
@@ -8,13 +8,18 @@ exports.run = (client,message,args,identifiedArgs) => {
     if (!client.commands.get(commandName)) return message.channel.send('Command not found/invalid command');
     const results = chrono.parse(identifiedArgs.t); // chrono parses natural language into datetime
     if (!results[0]) return message.channel.send(`Couldn't parse '${identifiedArgs.t}' into a valid time.\nTry something like: 9:35pm ET`);
-    let datedResult = results[0].start.date(); //get a javascript date object
+    let datedResult = results[0].start.date(); //get a javascript date object (not really needed I guess? could just pull from results directly)
     //set the cronjob for every day using specified hours/minutes
     let job = new CronJob(`${datedResult.getMinutes()} ${datedResult.getHours()} * * *`, () => {
         //we need to split the data in 'a' to an array. If they didn't specify any args pass an empty array 
         let argsToPass = !identifiedArgs.a ? [] : identifiedArgs.a.trim().split(/ +/g); 
         //get the command from the enmap and pass it what it needs
-        client.commands.get(commandName).run(client,message,argsToPass);
+        try {
+            client.commands.get(commandName).run(client,message,argsToPass);
+        } catch(err) {
+            message.channel.send(`Error with trigger ${commandName}: ${err}`);
+            job.stop();
+        }
     });
     job.start();
     //TODO save needed data to creat cronjob in a persitent enmap

--- a/commands/settrigger.js
+++ b/commands/settrigger.js
@@ -23,10 +23,8 @@ exports.run = (client,message,args,identifiedArgs) => {
         }
     });
     job.start();
-    //make sure that we have a triggers array to push to
-    if (!client.triggers.ensure(message.guild.id).triggers) client.triggers.set(message.guild.id, {triggers: []});
     //get the current triggers
-    let currentTriggers = client.triggers.ensure(message.guild.id).triggers;
+    let currentTriggers = client.triggers.ensure(message.guild.id, {triggers: []}).triggers;
     //push a new object to the array
     currentTriggers.push({
         channel: message.channel.id,

--- a/commands/settrigger.js
+++ b/commands/settrigger.js
@@ -12,7 +12,7 @@ exports.run = (client,message,args,identifiedArgs) => {
     //we need to split the data in 'a' to an array. If they didn't specify any args pass an empty array 
     let argsToPass = !identifiedArgs.a ? [] : identifiedArgs.a.trim().split(/ +/g); 
     //construct the cronjob time
-    let cronTime = `${datedResult.getMinutes()} ${datedResult.getHours()} * * *`
+    let cronTime = `${datedResult.getMinutes()} ${datedResult.getHours()} * * *`;
     let job = new CronJob(cronTime, () => {       
         //get the command from the enmap and pass it what it needs
         try {

--- a/commands/settrigger.js
+++ b/commands/settrigger.js
@@ -4,15 +4,17 @@ const { CronJob } = require('cron');
 exports.run = (client,message,args,identifiedArgs) => {
     if (!identifiedArgs.t) return message.channel.send('Please specify a time with -t time');
     if (!identifiedArgs.c) return message.channel.send('Please specify a command with -c command');
-    if (!client.commands.get(identifiedArgs.c)) return message.channel.send('Command not found/invalid command');
+    const commandName = identifiedArgs.c.trim().toLowerCase(); //trim it and make sure it's lowercase as all enmap keys are lowecase
+    if (!client.commands.get(commandName)) return message.channel.send('Command not found/invalid command');
     const results = chrono.parse(identifiedArgs.t); // chrono parses natural language into datetime
+    if (!results[0]) return message.channel.send(`Couldn't parse '${identifiedArgs.t}' into a valid time.\nTry something like: 9:35pm ET`);
     let datedResult = results[0].start.date(); //get a javascript date object
     //set the cronjob for every day using specified hours/minutes
     let job = new CronJob(`${datedResult.getMinutes()} ${datedResult.getHours()} * * *`, () => {
         //we need to split the data in 'a' to an array. If they didn't specify any args pass an empty array 
         let argsToPass = !identifiedArgs.a ? [] : identifiedArgs.a.trim().split(/ +/g); 
         //get the command from the enmap and pass it what it needs
-        client.commands.get(identifiedArgs.c).run(client,message,argsToPass);
+        client.commands.get(commandName).run(client,message,argsToPass);
     });
     job.start();
     //TODO save needed data to creat cronjob in a persitent enmap

--- a/commands/triggers.js
+++ b/commands/triggers.js
@@ -1,0 +1,19 @@
+const {MessageEmbed} = require('discord.js');
+
+exports.run = (client, message, args) => {
+    let triggerString = '';
+    let triggers = client.triggers.ensure(message.guild.id, []);
+    let index = 1; //start index at 1 for user readability
+    for(let trigger of triggers) {
+        let times = trigger.cronTime.split(" "); //split the times up because we just want hours and minutes
+        let time = `${times[1]}:${times[0]} CST`; // ex 5:30 CST , index 1 is hours, 0 is minutes
+        triggerString += `[**${index}**] ${trigger.commandName}(${trigger.args.join(" ")}) at ${time}\n`; //construct string to display
+        index++;
+    }
+    const embed = new MessageEmbed()
+        .setColor('#d4af37')
+        .setTitle('Triggers')
+        .addField('__Current command triggers:__', triggerString != '' ? triggerString : 'None'); //check if triggerstring has actual content
+
+    message.channel.send({embeds:[embed]}); 
+}

--- a/index.js
+++ b/index.js
@@ -79,7 +79,7 @@ const setTriggers = () => {
             //add cronjob to array so we can access all the cronjobs from any command
             client.cronJobs.push(job);
             job.start();
-            console.log(`Set trigged command ${trigger.commandName} at ${trigger.cronTime} for ${server}`);
+            console.log(`Set triggered command ${trigger.commandName} at ${trigger.cronTime} for ${server}`);
         }
     }
 }

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "enmap": "latest",
     "node-fetch": "latest",
     "geo-tz": "latest",
-    "cron": "latest"
+    "cron": "latest",
+    "chrono-node": "latest"
   }
 }


### PR DESCRIPTION
Adds four new commands.
$settrigger -t time -c command -a args...
Allows a server administrator to specify a command to run at the specified hour/minutes every day (optionally with arguments).
Will use the channel that the command was run in for the triggered command.
$triggers
Displays current triggers for that server
$removetrigger (ID)
Allows a server administrator to remove a trigger based on the numerical ID displayed in $triggers
This is the best way I can think of ID'ing triggers for now other than having them specify a name for each one.
$cleartriggers
Bot-owner command that stops all cronjobs and deletes ALL triggers globally (for each server)


There's definitely more work to be done formatting/making stuff look nice, but this allows basic functionality